### PR TITLE
improve workflows and add automated formula update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,15 @@ on:
     types:
       - labeled
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,12 +6,18 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-bot:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-13]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -37,5 +43,5 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: bottles_${{ matrix.os }}
+          name: bottles_${{ matrix.os }}_${{ github.run_id }}
           path: '*.bottle.*'

--- a/.github/workflows/update-formula.yaml
+++ b/.github/workflows/update-formula.yaml
@@ -1,0 +1,44 @@
+name: Update formula
+
+on:
+  repository_dispatch:
+    types: [new-release]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update asdasdsa.rb
+        env:
+          TAG: ${{ github.event.client_payload.tag }}
+          SHA256: ${{ github.event.client_payload.sha256 }}
+        run: |
+          sed -i \
+            "s|url \"https://github.com/rvigo/asdasdsa/archive/refs/tags/v[^\"]*\"|url \"https://github.com/rvigo/asdasdsa/archive/refs/tags/${TAG}.tar.gz\"|" \
+            asdasdsa.rb
+          sed -i \
+            "s/sha256 \"[a-f0-9]\{64\}\"/sha256 \"${SHA256}\"/" \
+            asdasdsa.rb
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.client_payload.tag }}
+        run: |
+          BRANCH="formula-update-${TAG}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git add asdasdsa.rb
+          git commit -m "update asdasdsa.rb for ${TAG}"
+          git push origin "${BRANCH}"
+          gh pr create \
+            --title "Update asdasdsa formula to ${TAG}" \
+            --body "Automated formula update triggered by release ${TAG}." \
+            --base main \
+            --head "${BRANCH}"


### PR DESCRIPTION
- add concurrency groups to tests and publish workflows
- add fail-fast: false and timeout-minutes to test-bot job
- include run_id in artifact names to prevent collisions
- add update-formula.yaml: listens for repository_dispatch from asdasdsa repo, patches asdasdsa.rb and opens a PR